### PR TITLE
feat: remove hardcoded path defaults, require Options configuration

### DIFF
--- a/src/main/java/com/mcs/camera/AlbumDetails.java
+++ b/src/main/java/com/mcs/camera/AlbumDetails.java
@@ -18,7 +18,7 @@ public class AlbumDetails {
                         boolean includeVideos, boolean inlineVideos, boolean keepOrder,
                         boolean tryFilenameDateTimeOnMetadataFail) {
         this(prefix, sourceDir, forceDateFlag, forceDate, includeVideos, inlineVideos, keepOrder,
-                tryFilenameDateTimeOnMetadataFail, "F:\\My Pictures", 1, "%03d", " ");
+                tryFilenameDateTimeOnMetadataFail, "", 1, "%03d", " ");
     }
 
     public AlbumDetails(String prefix, String sourceDir, boolean forceDateFlag, String forceDate,

--- a/src/main/java/com/mcs/camera/AppPreferences.java
+++ b/src/main/java/com/mcs/camera/AppPreferences.java
@@ -10,8 +10,8 @@ public class AppPreferences {
     private static final String KEY_NUMBER_PADDING = "numberPadding";
     private static final String KEY_FILENAME_SEPARATOR = "filenameSeparator";
 
-    private static final String DEFAULT_PICTURE_LIBRARY_DIR = "F:\\My Pictures";
-    private static final String DEFAULT_DEFAULT_SOURCE_DIR = "H:\\Picture Merge";
+    private static final String DEFAULT_PICTURE_LIBRARY_DIR = "";
+    private static final String DEFAULT_DEFAULT_SOURCE_DIR = "";
     private static final int DEFAULT_COUNTER_START = 1;
     private static final int DEFAULT_NUMBER_PADDING = 3;
     private static final String DEFAULT_FILENAME_SEPARATOR = " ";
@@ -64,5 +64,9 @@ public class AppPreferences {
 
     public String getNumberFormat() {
         return "%0" + getNumberPadding() + "d";
+    }
+
+    public boolean isConfigured() {
+        return !getPictureLibraryDir().isEmpty() && !getDefaultSourceDir().isEmpty();
     }
 }

--- a/src/main/java/com/mcs/camera/UIHandler.java
+++ b/src/main/java/com/mcs/camera/UIHandler.java
@@ -411,6 +411,14 @@ public class UIHandler {
         boolean tryFilenameDateTimeOnMetadataFail = tryFilenameDateTimeCheckBox.isSelected();
 
         // Validation
+        if (!appPreferences.isConfigured()) {
+            JOptionPane.showMessageDialog(mainFrame,
+                    "Please configure your directories in Edit > Options... before processing.",
+                    "Options Required", JOptionPane.WARNING_MESSAGE);
+            showOptionsDialog();
+            return;
+        }
+
         if (prefix.isEmpty()) {
             JOptionPane.showMessageDialog(mainFrame, "Album name cannot be empty.", "Input Error",
                     JOptionPane.ERROR_MESSAGE);
@@ -545,6 +553,14 @@ public class UIHandler {
         boolean inlineVideos = renumberInlineVideosCheckBox.isSelected();
 
         // Validation
+        if (!appPreferences.isConfigured()) {
+            JOptionPane.showMessageDialog(mainFrame,
+                    "Please configure your directories in Edit > Options... before processing.",
+                    "Options Required", JOptionPane.WARNING_MESSAGE);
+            showOptionsDialog();
+            return;
+        }
+
         if (directory.isEmpty()) {
             JOptionPane.showMessageDialog(mainFrame, "Album directory cannot be empty.", "Input Error",
                     JOptionPane.ERROR_MESSAGE);

--- a/src/test/java/com/mcs/camera/AppPreferencesTest.java
+++ b/src/test/java/com/mcs/camera/AppPreferencesTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class AppPreferencesTest {
 
@@ -19,11 +19,28 @@ public class AppPreferencesTest {
     public void testDefaults() {
         AppPreferences prefs = new AppPreferences();
 
-        assertEquals("F:\\My Pictures", prefs.getPictureLibraryDir());
-        assertEquals("H:\\Picture Merge", prefs.getDefaultSourceDir());
+        assertEquals("", prefs.getPictureLibraryDir());
+        assertEquals("", prefs.getDefaultSourceDir());
         assertEquals(1, prefs.getCounterStart());
         assertEquals(3, prefs.getNumberPadding());
         assertEquals(" ", prefs.getFilenameSeparator());
+    }
+
+    @Test
+    public void testIsConfiguredFalseByDefault() {
+        AppPreferences prefs = new AppPreferences();
+        assertFalse(prefs.isConfigured());
+    }
+
+    @Test
+    public void testIsConfiguredRequiresBothPaths() {
+        AppPreferences prefs = new AppPreferences();
+
+        prefs.setPictureLibraryDir("C:\\Photos");
+        assertFalse(prefs.isConfigured());
+
+        prefs.setDefaultSourceDir("D:\\Import");
+        assertTrue(prefs.isConfigured());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Path defaults changed from hardcoded Windows paths to empty strings
- On a fresh install, both Process and Renumber are blocked with a prompt to configure directories via Edit > Options...
- Added `AppPreferences.isConfigured()` check requiring both paths to be set
- Added tests for `isConfigured()` behavior

## Test plan
- [ ] Clear registry prefs (or test on fresh machine), launch app — source dir field should be empty
- [ ] Click Process — should show warning and open Options dialog
- [ ] Click Renumber — should show warning and open Options dialog
- [ ] Configure paths in Options, click OK — processing should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)