### PR TITLE
docs: update README and CLAUDE.md for CLI, dry-run, and rollback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Picture Renamer is a Windows desktop application (Java Swing) that batch-renames photos and videos based on EXIF/metadata date-taken timestamps, then moves them into an organized album directory structure under `F:\My Pictures\{year}\{date}, {albumName}\`. It also includes a built-in renumbering tool for re-sequencing files in existing albums.
+Picture Renamer is a Windows desktop application (Java Swing + CLI) that batch-renames photos and videos based on EXIF/metadata date-taken timestamps, then moves them into an organized album directory structure under `{pictureLibrary}\{year}\{date}, {albumName}\`. It also includes a built-in renumbering tool for re-sequencing files in existing albums. Both workflows are available via the GUI or the command-line interface.
 
 **Current version:** 4.0
 
@@ -28,13 +28,16 @@ mvn test -Dtest=PictureRenamerTest#testParseDateFromFilename  # Run single test
 
 ```
 src/main/java/com/mcs/camera/
-├── Main.java                  # Entry point — singleton lock, JNA window focus, version loading
-├── AlbumDetails.java          # Immutable DTO for user-specified album settings
-├── AppPreferences.java        # Persistent user preferences via java.util.prefs.Preferences
-├── PictureRenamer.java        # Core rename engine — metadata → sort → rename → move
-├── PictureRenumberer.java     # Re-sequencing engine — metadata → sort → two-pass rename in place
-├── UIHandler.java             # Swing UI — tabbed frame, menu bar, Options dialog, SwingWorker processing
-├── FilenameComparator.java    # Natural sort (numeric-aware) comparator
+├── Main.java                       # Entry point — CLI dispatch or singleton lock + GUI launch
+├── CliHandler.java                 # CLI interface — rename/renumber subcommands via commons-cli
+├── AlbumDetails.java               # Immutable DTO for user-specified album settings
+├── AppPreferences.java             # Persistent user preferences via java.util.prefs.Preferences
+├── PictureRenamer.java             # Core rename engine — metadata → sort → rename → move
+├── PictureRenumberer.java          # Re-sequencing engine — metadata → sort → two-pass rename in place
+├── FileOperationTracker.java       # Tracks file moves for rollback on failure
+├── DryRunFileOperationTracker.java  # Dry-run variant — logs operations without executing
+├── UIHandler.java                  # Swing UI — tabbed frame, menu bar, Options dialog, SwingWorker processing
+├── FilenameComparator.java         # Natural sort (numeric-aware) comparator
 └── extractor/
     ├── MetadataExtractor.java      # Interface: extractDateTaken(File) → LocalDateTime
     ├── JpgMetadataExtractor.java   # EXIF SubIFD TAG_DATETIME_ORIGINAL
@@ -51,9 +54,15 @@ src/main/resources/
 └── icon-256.png
 
 src/test/java/com/mcs/camera/
-├── AlbumDetailsTest.java      # DTO construction test
-├── AppPreferencesTest.java    # Preferences persistence and defaults tests
-└── PictureRenamerTest.java    # Filename parsing, metadata extraction, file listing tests (TemporaryFolder-based)
+├── AlbumDetailsTest.java              # DTO construction test
+├── AppPreferencesTest.java            # Preferences persistence and defaults tests
+├── CliHandlerTest.java                # CLI argument parsing and dispatch tests
+├── FileOperationTrackerTest.java      # Move tracking and rollback tests
+├── DryRunFileOperationTrackerTest.java # Dry-run operation logging tests
+├── PictureRenamerTest.java            # Filename parsing, metadata extraction, file listing tests
+├── PictureRenamerDryRunTest.java      # Rename dry-run integration tests
+├── PictureRenumbererTest.java         # Renumbering integration tests
+└── PictureRenumbererDryRunTest.java   # Renumber dry-run integration tests
 
 dist/
 ├── PictureRenamer.jar   # Deployable fat JAR (built by mvn package)
@@ -68,26 +77,30 @@ dist/
 
 ## Architecture
 
-**Entry point:** `Main` — acquires a file-based singleton lock (`~/.PictureRenamer.lock`), uses JNA to focus an existing window if already running, then launches the Swing UI. Exposes `getAppTitle()` (static `"Picture Renamer"`) and `getAppVersion()` (from `app.properties`).
+**Entry point:** `Main` — if CLI args are present, delegates to `CliHandler` and exits with the return code. Otherwise, acquires a file-based singleton lock (`~/.PictureRenamer.lock`), uses JNA to focus an existing window if already running, then launches the Swing UI. Exposes `getAppTitle()` (static `"Picture Renamer"`) and `getAppVersion()` (from `app.properties`).
 
-**UI:** `UIHandler` builds a real `JFrame` with:
+**CLI:** `CliHandler` provides `rename` and `renumber` subcommands with full flag support via Apache Commons CLI. Supports `--help`, `--version`, and `--dry-run`. Constructs `AlbumDetails` from flags and delegates to `PictureRenamer`/`PictureRenumberer`.
+
+**UI:** `UIHandler` builds a `JFrame` with:
 - **Menu bar:** File (Exit), Edit (Options...), Help (About)
 - **Tabbed pane:** "Rename" tab for the rename-and-move workflow, "Renumber" tab for in-place re-sequencing
 - **SwingWorker:** Both tabs run their processing off the EDT to keep the UI responsive
-- Form fields are persistent class members — no more JOptionPane-driven input loops
+- Form fields are persistent class members
 
 **Rename flow** (via `PictureRenamer`):
 1. Reads all files from source directory
 2. Extracts date-taken metadata per file type using the `extractor` package
 3. Builds a sorted list of `"dateTaken fileName"` temporary keys for ordering
-4. Renames files sequentially as `{prefix} 001.{ext}`, `{prefix} 002.{ext}`, etc.
-5. Moves renamed files to `F:\My Pictures\{year}\{albumDirName}\`
+4. Renames files sequentially as `{prefix}{sep}001.{ext}`, `{prefix}{sep}002.{ext}`, etc.
+5. Moves renamed files to `{pictureLibrary}\{year}\{albumDirName}\`
 
 **Renumber flow** (via `PictureRenumberer`):
 1. Reads all files from an existing album directory
 2. Extracts metadata and sorts chronologically
-3. Two-pass rename: randomize all names first (avoid collisions), then re-sequence as `{prefix} 001.{ext}`, etc.
+3. Two-pass rename: randomize all names first (avoid collisions), then re-sequence as `{prefix}{sep}001.{ext}`, etc.
 4. Files stay in place — no move step
+
+**File operation tracking:** `FileOperationTracker` wraps `Files.move()` and records each operation so the entire batch can be rolled back on failure. `DryRunFileOperationTracker` overrides this to log planned operations without executing them.
 
 **Metadata extraction:** `MetadataExtractor` interface with per-format implementations. Uses the `com.drew:metadata-extractor` library for EXIF reading. Note: JPG and HEIC extractors are currently identical; PNG uses file-modified date; Video uses `file.lastModified()`.
 
@@ -100,12 +113,12 @@ dist/
 | `metadata-extractor` 2.19.0 | EXIF/metadata reading |
 | `jna` + `jna-platform` 5.18.1 | Windows native calls (User32) |
 | `commons-io` 2.21.0 | File utilities |
-| `commons-lang3` 3.17.0 | String utilities (RandomStringUtils) |
-| `flatlaf` 3.6 | Modern Swing Look and Feel |
+| `commons-lang3` 3.20.0 | String utilities (RandomStringUtils) |
+| `commons-cli` 1.11.0 | CLI argument parsing |
+| `flatlaf` 3.7 | Modern Swing Look and Feel |
 | `logback-classic` 1.5.32 | SLF4J logging |
-| `commons-cli` 1.11.0 | CLI parsing (declared but unused) |
 | `junit` 4.13.2 | Testing |
-| `launch4j-maven-plugin` 2.5.2 | Wraps fat JAR into Windows .exe |
+| `launch4j-maven-plugin` 2.7.0 | Wraps fat JAR into Windows .exe |
 
 ## Key Design Notes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Picture Renamer
 
-A Windows desktop application that batch-renames photos and videos by date taken, then organizes them into a clean album directory structure. Also includes a built-in renumbering tool for re-sequencing existing albums. Built with Java Swing.
+A Windows desktop application that batch-renames photos and videos by date taken, then organizes them into a clean album directory structure. Also includes a built-in renumbering tool for re-sequencing existing albums. Available as both a GUI (Java Swing) and a CLI.
 
 ## What It Does
 
@@ -28,7 +28,7 @@ Re-sequences files in an existing album directory. Useful when you need to reord
 
 ## Features
 
-- **Tabbed interface** — Switch between Rename and Renumber modes in a single window
+- **GUI and CLI** — Use the tabbed Swing interface or script operations from the command line
 - **Persistent options** — Configure picture library directory, default source directory, counter start, number padding, and filename separator via Edit > Options... (stored in Windows Registry)
 - **EXIF-aware sorting** — Photos are ordered by the actual moment they were captured, not by filename
 - **Multi-format support** — Handles JPG, HEIC, PNG, and common video formats (MP4, MOV, AVI, MTS, M2TS)
@@ -36,6 +36,8 @@ Re-sequences files in an existing album directory. Useful when you need to reord
 - **Force date override** — Manually set a date for files with no usable timestamp
 - **Keep order mode** — Skip metadata entirely and sort by filename (natural/numeric sort)
 - **Video handling options** — Include or exclude videos; number them inline with photos or append at the end
+- **Dry run** — Preview what would happen without making any changes (CLI)
+- **Rollback on failure** — File moves are tracked and automatically reversed if an error occurs mid-operation
 - **Single-instance enforcement** — Only one copy of the app runs at a time; re-launching focuses the existing window
 - **Menu bar** — File (Exit), Edit (Options...), Help (About with version info)
 
@@ -44,22 +46,116 @@ Re-sequences files in an existing album directory. Useful when you need to reord
 - **OS:** Windows (uses Windows-native APIs)
 - **Runtime:** Java 17+
 
-## First Run
-
-On first launch, you must configure your directories via **Edit > Options...** before processing:
-
-- **Picture library** — Home directory of your picture library (e.g., `F:\My Pictures`). Renamed files are moved here, and the Renumber tab browses here by default.
-- **Default source directory** — Where your camera/phone dumps files for import (e.g., `H:\Picture Merge`).
-
 ## Installation
 
-Download `PictureRenamer.exe` from the `dist/` directory and double-click to run. Requires Java 17+ installed.
+Download `PictureRenamer.exe` from the [latest release](https://github.com/msiege2/picture-renamer/releases) and double-click to run. Requires Java 17+ installed.
 
 Alternatively, run the JAR directly:
 
 ```
-java -jar dist/PictureRenamer.jar
+java -jar PictureRenamer.jar
 ```
+
+## First Run
+
+On first launch, configure your directories via **Edit > Options...** before processing:
+
+- **Picture library** — Home directory of your picture library (e.g., `F:\My Pictures`). Renamed files are moved here, and the Renumber tab browses here by default.
+- **Default source directory** — Where your camera/phone dumps files for import (e.g., `H:\Picture Merge`).
+
+## CLI Usage
+
+Pass any argument to use the CLI instead of the GUI.
+
+```
+java -jar PictureRenamer.jar <command> [options]
+```
+
+### Global Options
+
+| Flag | Description |
+|---|---|
+| `--help`, `-h` | Show help message |
+| `--version`, `-v` | Show version |
+
+### Rename Command
+
+```
+java -jar PictureRenamer.jar rename --source <dir> --dest <dir> --prefix <name> [options]
+```
+
+| Flag | Description |
+|---|---|
+| `--source <dir>` | **(required)** Source directory containing photos/videos |
+| `--dest <dir>` | **(required)** Destination base directory (e.g., `F:\My Pictures`) |
+| `--prefix <name>` | **(required)** Album name prefix |
+| `--force-date <YYYY-MM-DD>` | Force a specific date for all files |
+| `--keep-order` | Keep original file order (natural sort, skips metadata) |
+| `--include-videos` | Include video files |
+| `--inline-videos` | Sort videos by date alongside photos (requires `--include-videos`) |
+| `--try-filename-date` | Try parsing date from filename when metadata fails |
+| `--counter-start <n>` | Starting counter (default: 1) |
+| `--number-padding <n>` | Number padding digits: 2, 3, or 4 (default: 3) |
+| `--separator <type>` | Filename separator: space, dash, underscore, none (default: space) |
+| `--dry-run` | Show what would happen without making changes |
+
+### Renumber Command
+
+```
+java -jar PictureRenamer.jar renumber --dir <dir> --prefix <name> [options]
+```
+
+| Flag | Description |
+|---|---|
+| `--dir <dir>` | **(required)** Album directory to renumber |
+| `--prefix <name>` | **(required)** New filename prefix |
+| `--include-videos` | Include video files |
+| `--inline-videos` | Sort videos by date alongside photos |
+| `--number-padding <n>` | Number padding digits: 2, 3, or 4 (default: 3) |
+| `--separator <type>` | Filename separator: space, dash, underscore, none (default: space) |
+| `--dry-run` | Show what would happen without making changes |
+
+## GUI Options
+
+### Edit > Options...
+
+| Setting | Description | Default |
+|---|---|---|
+| **Picture library** | Home directory of your picture library — rename destination and renumber browse root | *(must be configured)* |
+| **Default source directory** | Default folder to import photos/videos from | *(must be configured)* |
+| **Counter start** | Starting number for file sequences | `1` |
+| **Number padding** | Number of digits (2, 3, or 4) for zero-padded file numbers | `3` |
+| **Filename separator** | Character between prefix and number: Space, Dash, Underscore, or None | `Space` |
+
+### Rename Tab
+
+| Option | Description |
+|---|---|
+| **Album Name** | The prefix used for renamed files (e.g., "Beach Trip") |
+| **Source Directory** | Folder containing the photos/videos to process (set via Options) |
+| **Force Date** | Override all file dates with a specific `YYYY-MM-DD` value |
+| **Include Videos** | Whether to process video files alongside photos |
+| **Number Videos Inline** | Sequence videos among photos by timestamp, or append them after all photos |
+| **Keep Order** | Sort by filename instead of metadata (uses natural/numeric sort) |
+| **Use Filename Date/Time** | Fall back to parsing `yyyy-MM-dd HH.mm.ss` from filenames when EXIF is missing |
+
+### Renumber Tab
+
+| Option | Description |
+|---|---|
+| **Album Directory** | The existing album directory to re-sequence |
+| **Album Prefix** | Auto-extracted from directory name (editable); used for renamed files |
+| **Include Videos** | Whether to include video files in the renumbering |
+| **Number Videos Inline** | Sequence videos among photos by timestamp, or append them after all photos |
+
+## Supported File Types
+
+| Type | Formats | Metadata Source |
+|---|---|---|
+| Photos | `.jpg`, `.jpeg` | EXIF SubIFD (DateTimeOriginal) |
+| Photos | `.heic` | EXIF SubIFD (DateTimeOriginal) |
+| Photos | `.png` | File system modified date |
+| Videos | `.mp4`, `.mov`, `.avi`, `.mts`, `.m2ts` | File system modified date |
 
 ## Building from Source
 
@@ -82,52 +178,11 @@ This produces a fat JAR at `dist/PictureRenamer.jar` and a Windows exe wrapper a
 mvn test
 ```
 
-## Options
-
-### Edit > Options...
-
-| Setting | Description | Default |
-|---|---|---|
-| **Picture library** | Home directory of your picture library — rename destination and renumber browse root | *(must be configured)* |
-| **Default source directory** | Default folder to import photos/videos from | *(must be configured)* |
-| **Counter start** | Starting number for file sequences | `1` |
-| **Number padding** | Number of digits (2, 3, or 4) for zero-padded file numbers | `3` |
-| **Filename separator** | Character between prefix and number: Space, Dash, Underscore, or None | `Space` |
-
-### Rename Options
-
-| Option | Description |
-|---|---|
-| **Album Name** | The prefix used for renamed files (e.g., "Beach Trip") |
-| **Source Directory** | Folder containing the photos/videos to process (set via Options) |
-| **Force Date** | Override all file dates with a specific `YYYY-MM-DD` value |
-| **Include Videos** | Whether to process video files alongside photos |
-| **Number Videos Inline** | Sequence videos among photos by timestamp, or append them after all photos |
-| **Keep Order** | Sort by filename instead of metadata (uses natural/numeric sort) |
-| **Use Filename Date/Time** | Fall back to parsing `yyyy-MM-dd HH.mm.ss` from filenames when EXIF is missing |
-
-### Renumber Options
-
-| Option | Description |
-|---|---|
-| **Album Directory** | The existing album directory to re-sequence |
-| **Album Prefix** | Auto-extracted from directory name (editable); used for renamed files |
-| **Include Videos** | Whether to include video files in the renumbering |
-| **Number Videos Inline** | Sequence videos among photos by timestamp, or append them after all photos |
-
-## Supported File Types
-
-| Type | Formats | Metadata Source |
-|---|---|---|
-| Photos | `.jpg`, `.jpeg` | EXIF SubIFD (DateTimeOriginal) |
-| Photos | `.heic` | EXIF SubIFD (DateTimeOriginal) |
-| Photos | `.png` | File system modified date |
-| Videos | `.mp4`, `.mov`, `.avi`, `.mts`, `.m2ts` | File system modified date |
-
 ## Tech Stack
 
 - **Language:** Java 17
 - **UI:** Swing with [FlatLaf](https://www.formdev.com/flatlaf/) Look and Feel
+- **CLI:** [Apache Commons CLI](https://commons.apache.org/proper/commons-cli/)
 - **Build:** Maven with shade plugin (fat JAR) + Launch4j (exe wrapper)
 - **EXIF:** [metadata-extractor](https://github.com/drewnoakes/metadata-extractor) by Drew Noakes
 - **Native:** [JNA](https://github.com/java-native-access/jna) for Win32 API calls


### PR DESCRIPTION
## Summary
- Add full CLI usage documentation (rename/renumber subcommands, all flags, dry-run)
- Document file operation tracking with rollback and dry-run support
- Add new source files and test files to CLAUDE.md project structure
- Fix stale dependency versions (FlatLaf 3.7, commons-lang3 3.20.0, launch4j 2.7.0)
- Correct commons-cli from "declared but unused" to actively used
- Update installation section to link GitHub releases instead of dist/

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Verify CLAUDE.md project structure matches actual file layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)